### PR TITLE
Fixed: Issue with onTurnEndEvent

### DIFF
--- a/scripts/manager_combat_tf.lua
+++ b/scripts/manager_combat_tf.lua
@@ -181,7 +181,7 @@ function onTurnEndEvent(nodeCT)
 					nodeFound = rOverride.node;
 				end
 			end
-			if nodeFound == nodeCT then
+			if nodeCT and nodeFound == nodeCT then
 				onTurnEndEventOriginal(nodeEntry);
 				break;
 			end


### PR DESCRIPTION
When nodeCT is nil, nodeFound will always match nodeCT at the end of the round and cause all actors to fire onTurnEndEvent. Maybe this is a ruleset bug as to why nodeCT is nil in the first place